### PR TITLE
output the version of the command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(strip $(VERSION_STRING)),)
+VERSION_STRING := $(shell git rev-parse --short HEAD)
+endif
+
+BINDIR    := $(CURDIR)/bin
+
+build:
+	go build -ldflags "-X github.com/okteto/cnd/cmd.VersionString=${VERSION_STRING}" -o ${BINDIR}/cnd

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// These values will be stamped at build time
+var (
+	// VersionString is the canonical version string
+	VersionString string
+)
+
+//Version returns information about the binary
+func Version() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "View the version of the cnd binary",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Printf("cnd version %s \n", VersionString)
+			return nil
+		},
+	}
+}

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ func main() {
 		cmd.Exec(),
 		cmd.Down(),
 		cmd.Rm(),
+		cmd.Version(),
 	)
 
 	if err := commands.Execute(); err != nil {


### PR DESCRIPTION
The version is injected during build. It defaults to the commit SHA, and it can be overridden by using the env var $VERSION_STRING (this should be injected by CI once we have automated releases)

![image](https://user-images.githubusercontent.com/475313/46906448-ed6d1280-cf03-11e8-857e-00abea71affe.png)
