### PR TITLE
User friendly messages

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -500,6 +500,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/sirupsen/logrus",
     "github.com/spf13/cobra",
     "gopkg.in/yaml.v2",
     "k8s.io/api/apps/v1",

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	log "github.com/sirupsen/logrus"
+	"fmt"
 
 	"github.com/okteto/cnd/syncthing"
 
@@ -21,12 +21,12 @@ func Down() *cobra.Command {
 			return executeDown(devPath)
 		},
 	}
-	cmd.Flags().StringVarP(&devPath, "file", "f", "cnd.yml", "manifest file")
+
 	return cmd
 }
 
 func executeDown(devPath string) error {
-	log.Info("Deactivating dev mode...")
+	fmt.Println("Deactivating dev mode...")
 
 	namespace, client, _, err := client.Get()
 	if err != nil {

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/okteto/cnd/syncthing"
 
@@ -26,7 +26,7 @@ func Down() *cobra.Command {
 }
 
 func executeDown(devPath string) error {
-	log.Println("Executing down...")
+	log.Info("Deactivating dev mode...")
 
 	namespace, client, _, err := client.Get()
 	if err != nil {

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -13,7 +13,6 @@ import (
 
 //Down stops a cloud native environment
 func Down() *cobra.Command {
-	var devPath string
 	cmd := &cobra.Command{
 		Use:   "down",
 		Short: "Stops a cloud native environment",

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -16,7 +16,6 @@ import (
 
 //Exec executes a command on the CND container
 func Exec() *cobra.Command {
-	var devPath string
 	cmd := &cobra.Command{
 		Use:   "exec COMMAND",
 		Short: "Execute a command in the cloud native environment",

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -32,7 +32,6 @@ func Exec() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&devPath, "file", "f", "cnd.yml", "manifest file")
 	return cmd
 }
 

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -13,15 +13,15 @@ import (
 
 //Rm removes a cloud native environment
 func Rm() *cobra.Command {
-	var devPath string
 	cmd := &cobra.Command{
 		Use:   "rm",
 		Short: "Remove a cloud native environment",
 		RunE: func(cmd *cobra.Command, args []string) error {
+
 			return executeRm(devPath)
 		},
 	}
-	cmd.Flags().StringVarP(&devPath, "file", "f", "cnd.yml", "manifest file")
+
 	return cmd
 }
 

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/okteto/cnd/k8/client"
 	"github.com/okteto/cnd/k8/deployments"
@@ -26,7 +26,7 @@ func Rm() *cobra.Command {
 }
 
 func executeRm(devPath string) error {
-	log.Println("Executing rm...")
+	log.Debug("Executing rm...")
 
 	namespace, client, _, err := client.Get()
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"os"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	logLevel string
+	devPath  string
+	root     = &cobra.Command{
+		Use:   "cnd [flags] COMMAND [ARG...]",
+		Short: "Manage cloud native environments",
+		PersistentPreRun: func(ccmd *cobra.Command, args []string) {
+			l, err := log.ParseLevel(logLevel)
+			if err == nil {
+				log.SetLevel(l)
+			}
+
+			ccmd.SilenceUsage = true
+		},
+	}
+)
+
+func init() {
+	root.PersistentFlags().StringVarP(&logLevel, "loglevel", "l", "warn", "The amount of information outputted (debug, info, warn, error)")
+	root.PersistentFlags().StringVarP(&devPath, "file", "f", "cnd.yml", "manifest file")
+	root.AddCommand(
+		Up(),
+		Exec(),
+		Down(),
+		Rm(),
+		Version(),
+	)
+}
+
+// Execute runs the root command
+func Execute() {
+	if err := root.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,7 @@ var (
 	logLevel string
 	devPath  string
 	root     = &cobra.Command{
-		Use:   "cnd [flags] COMMAND [ARG...]",
+		Use:   "cnd COMMAND [ARG...]",
 		Short: "Manage cloud native environments",
 		PersistentPreRun: func(ccmd *cobra.Command, args []string) {
 			l, err := log.ParseLevel(logLevel)

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/okteto/cnd/k8/client"
 	"github.com/okteto/cnd/k8/deployments"
@@ -30,7 +30,7 @@ func Up() *cobra.Command {
 }
 
 func executeUp(devPath string) error {
-	log.Println("Executing up...")
+	log.Info("Activating dev mode...")
 
 	namespace, client, restConfig, err := client.Get()
 	if err != nil {
@@ -72,7 +72,7 @@ func executeUp(devPath string) error {
 		return err
 	}
 
-	pf, err := forward.NewCNDPortForward(sy.RemoteAddress)
+	pf, err := forward.NewCNDPortForward(dev.Mount.Source, sy.RemoteAddress, deployments.GetFullName(namespace, dev.Name))
 	if err != nil {
 		return err
 	}
@@ -88,7 +88,7 @@ func executeUp(devPath string) error {
 
 func stop(sy *syncthing.Syncthing, pf *forward.CNDPortForward) {
 	if err := sy.Stop(); err != nil {
-		log.Printf(err.Error())
+		log.Error(err)
 	}
 
 	pf.Stop()

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	log "github.com/sirupsen/logrus"
 
 	"github.com/okteto/cnd/k8/client"
@@ -24,13 +26,12 @@ func Up() *cobra.Command {
 			return executeUp(devPath)
 		},
 	}
-	cmd.Flags().StringVarP(&devPath, "file", "f", "cnd.yml", "manifest file")
 
 	return cmd
 }
 
 func executeUp(devPath string) error {
-	log.Info("Activating dev mode...")
+	fmt.Println("Activating dev mode...")
 
 	namespace, client, restConfig, err := client.Get()
 	if err != nil {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -17,8 +17,6 @@ import (
 
 //Up starts or upgrades a cloud native environment
 func Up() *cobra.Command {
-	var devPath string
-
 	cmd := &cobra.Command{
 		Use:   "up",
 		Short: "Starts or upgrades a cloud native environment",

--- a/k8/deployments/deployments.go
+++ b/k8/deployments/deployments.go
@@ -2,9 +2,10 @@ package deployments
 
 import (
 	"fmt"
-	"log"
 	"strings"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,7 +14,7 @@ import (
 
 //Deploy deploys a k8 deployment
 func Deploy(d *appsv1.Deployment, namespace string, c *kubernetes.Clientset) error {
-	deploymentName := fmt.Sprintf("%s/%s", namespace, d.Name)
+	deploymentName := GetFullName(namespace, d.Name)
 	dClient := c.AppsV1().Deployments(namespace)
 	dk8, err := dClient.Get(d.Name, metav1.GetOptions{})
 	if err != nil && !strings.Contains(err.Error(), "not found") {
@@ -21,21 +22,21 @@ func Deploy(d *appsv1.Deployment, namespace string, c *kubernetes.Clientset) err
 	}
 
 	if dk8.Name == "" {
-		log.Printf("Creating deployment '%s'...", deploymentName)
+		log.Debugf("Creating deployment '%s'...", deploymentName)
 		_, err = dClient.Create(d)
 		if err != nil {
 			return fmt.Errorf("Error creating kubernetes deployment: %s", err)
 		}
-		log.Printf("Created deployment %s.", deploymentName)
+		log.Debugf("Created deployment %s.", deploymentName)
 	} else {
-		log.Printf("Updating deployment '%s'...", deploymentName)
+		log.Debugf("Updating deployment '%s'...", deploymentName)
 		_, err = dClient.Update(d)
 		if err != nil {
 			return fmt.Errorf("Error updating kubernetes deployment: %s", err)
 		}
 	}
 
-	log.Printf("Waiting for the deployment '%s' to be ready...", deploymentName)
+	log.Debugf("Waiting for the deployment '%s' to be ready...", deploymentName)
 	tries := 0
 	for tries < 60 {
 		tries++
@@ -45,7 +46,7 @@ func Deploy(d *appsv1.Deployment, namespace string, c *kubernetes.Clientset) err
 			return fmt.Errorf("Error getting kubernetes deployment: %s", err)
 		}
 		if d.Status.ReadyReplicas == 1 && d.Status.UpdatedReplicas == 1 {
-			log.Printf("Kubernetes deployment '%s' is ready.", deploymentName)
+			log.Debugf("Kubernetes deployment '%s' is ready.", deploymentName)
 			return nil
 		}
 	}
@@ -54,8 +55,8 @@ func Deploy(d *appsv1.Deployment, namespace string, c *kubernetes.Clientset) err
 
 //Destroy destroysa k8 deployment
 func Destroy(d *appsv1.Deployment, namespace string, c *kubernetes.Clientset) error {
-	deploymentName := fmt.Sprintf("%s/%s", namespace, d.Name)
-	log.Printf("Deleting deployment '%s'...", deploymentName)
+	deploymentName := GetFullName(namespace, d.Name)
+	log.Debugf("Deleting deployment '%s'...", deploymentName)
 	dClient := c.AppsV1beta1().Deployments(namespace)
 	deletePolicy := metav1.DeletePropagationForeground
 	err := dClient.Delete(d.Name, &metav1.DeleteOptions{PropagationPolicy: &deletePolicy})
@@ -66,7 +67,7 @@ func Destroy(d *appsv1.Deployment, namespace string, c *kubernetes.Clientset) er
 		return fmt.Errorf("Error getting kubernetes deployment: %s", err)
 	}
 
-	log.Printf("Waiting for the deployment '%s' to be deleted...", deploymentName)
+	log.Debugf("Waiting for the deployment '%s' to be deleted...", deploymentName)
 	tries := 0
 	for tries < 10 {
 		tries++
@@ -74,11 +75,16 @@ func Destroy(d *appsv1.Deployment, namespace string, c *kubernetes.Clientset) er
 		_, err := dClient.Get(d.Name, metav1.GetOptions{})
 		if err != nil {
 			if strings.Contains(err.Error(), "not found") {
-				log.Printf("Deployment '%s' successfully deleted.", deploymentName)
+				log.Infof("Deployment '%s' successfully deleted.", deploymentName)
 				return nil
 			}
 			return fmt.Errorf("Error getting %s: %s", deploymentName, err)
 		}
 	}
 	return fmt.Errorf("%s not deleted after 50s", deploymentName)
+}
+
+// GetFullName returns the full name of the deployment. This is mostly used for logs and labels
+func GetFullName(deploymentName, namespace string) string {
+	return fmt.Sprintf("%s/%s", namespace, deploymentName)
 }

--- a/k8/deployments/deployments.go
+++ b/k8/deployments/deployments.go
@@ -85,6 +85,6 @@ func Destroy(d *appsv1.Deployment, namespace string, c *kubernetes.Clientset) er
 }
 
 // GetFullName returns the full name of the deployment. This is mostly used for logs and labels
-func GetFullName(deploymentName, namespace string) string {
+func GetFullName(namespace, deploymentName string) string {
 	return fmt.Sprintf("%s/%s", namespace, deploymentName)
 }

--- a/k8/deployments/deployments.go
+++ b/k8/deployments/deployments.go
@@ -22,21 +22,21 @@ func Deploy(d *appsv1.Deployment, namespace string, c *kubernetes.Clientset) err
 	}
 
 	if dk8.Name == "" {
-		log.Debugf("Creating deployment '%s'...", deploymentName)
+		log.Infof("Creating deployment '%s'...", deploymentName)
 		_, err = dClient.Create(d)
 		if err != nil {
 			return fmt.Errorf("Error creating kubernetes deployment: %s", err)
 		}
-		log.Debugf("Created deployment %s.", deploymentName)
+		log.Infof("Created deployment %s.", deploymentName)
 	} else {
-		log.Debugf("Updating deployment '%s'...", deploymentName)
+		log.Infof("Updating deployment '%s'...", deploymentName)
 		_, err = dClient.Update(d)
 		if err != nil {
 			return fmt.Errorf("Error updating kubernetes deployment: %s", err)
 		}
 	}
 
-	log.Debugf("Waiting for the deployment '%s' to be ready...", deploymentName)
+	log.Infof("Waiting for the deployment '%s' to be ready...", deploymentName)
 	tries := 0
 	for tries < 60 {
 		tries++
@@ -46,7 +46,7 @@ func Deploy(d *appsv1.Deployment, namespace string, c *kubernetes.Clientset) err
 			return fmt.Errorf("Error getting kubernetes deployment: %s", err)
 		}
 		if d.Status.ReadyReplicas == 1 && d.Status.UpdatedReplicas == 1 {
-			log.Debugf("Kubernetes deployment '%s' is ready.", deploymentName)
+			log.Infof("Kubernetes deployment '%s' is ready.", deploymentName)
 			return nil
 		}
 	}
@@ -56,7 +56,7 @@ func Deploy(d *appsv1.Deployment, namespace string, c *kubernetes.Clientset) err
 //Destroy destroysa k8 deployment
 func Destroy(d *appsv1.Deployment, namespace string, c *kubernetes.Clientset) error {
 	deploymentName := GetFullName(namespace, d.Name)
-	log.Debugf("Deleting deployment '%s'...", deploymentName)
+	log.Infof("Deleting deployment '%s'...", deploymentName)
 	dClient := c.AppsV1beta1().Deployments(namespace)
 	deletePolicy := metav1.DeletePropagationForeground
 	err := dClient.Delete(d.Name, &metav1.DeleteOptions{PropagationPolicy: &deletePolicy})
@@ -67,7 +67,7 @@ func Destroy(d *appsv1.Deployment, namespace string, c *kubernetes.Clientset) er
 		return fmt.Errorf("Error getting kubernetes deployment: %s", err)
 	}
 
-	log.Debugf("Waiting for the deployment '%s' to be deleted...", deploymentName)
+	log.Infof("Waiting for the deployment '%s' to be deleted...", deploymentName)
 	tries := 0
 	for tries < 10 {
 		tries++

--- a/k8/forward/forward.go
+++ b/k8/forward/forward.go
@@ -7,8 +7,6 @@ import (
 	"net/url"
 	"strconv"
 
-	log "github.com/sirupsen/logrus"
-
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -80,8 +78,10 @@ func (p *CNDPortForward) Start(c *kubernetes.Clientset, config *rest.Config, pod
 	go func() {
 		select {
 		case <-pf.Ready:
-			log.Infof("Linking '%s' to %s...", p.LocalPath, p.DeploymentName)
-			log.Infof("Ready! Go to your local IDE and continue coding!")
+			fmt.Printf("Linking '%s' to %s...", p.LocalPath, p.DeploymentName)
+			fmt.Println()
+			fmt.Printf("Ready! Go to your local IDE and continue coding!")
+			fmt.Println()
 			p.IsReady = true
 		}
 	}()

--- a/k8/forward/forward.go
+++ b/k8/forward/forward.go
@@ -3,10 +3,11 @@ package forward
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 	"strconv"
+
+	log "github.com/sirupsen/logrus"
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -17,16 +18,18 @@ import (
 
 //CNDPortForward holds the information of the port forward
 type CNDPortForward struct {
-	StopChan   chan struct{}
-	ReadyChan  chan struct{}
-	IsReady    bool
-	LocalPort  int
-	RemotePort int
-	Out        *bytes.Buffer
+	StopChan       chan struct{}
+	ReadyChan      chan struct{}
+	IsReady        bool
+	LocalPort      int
+	RemotePort     int
+	LocalPath      string
+	DeploymentName string
+	Out            *bytes.Buffer
 }
 
 //NewCNDPortForward initializes and returns a new port forward structure
-func NewCNDPortForward(remoteAddress string) (*CNDPortForward, error) {
+func NewCNDPortForward(localPath, remoteAddress, deploymentName string) (*CNDPortForward, error) {
 	parsed, err := url.Parse(remoteAddress)
 	if err != nil {
 		return nil, err
@@ -35,12 +38,14 @@ func NewCNDPortForward(remoteAddress string) (*CNDPortForward, error) {
 	port, _ := strconv.Atoi(parsed.Port())
 
 	return &CNDPortForward{
-		LocalPort:  port,
-		RemotePort: 22000,
-		StopChan:   make(chan struct{}, 1),
-		ReadyChan:  make(chan struct{}, 1),
-		Out:        new(bytes.Buffer),
-		IsReady:    false,
+		LocalPort:      port,
+		RemotePort:     22000,
+		StopChan:       make(chan struct{}, 1),
+		ReadyChan:      make(chan struct{}, 1),
+		Out:            new(bytes.Buffer),
+		LocalPath:      localPath,
+		DeploymentName: deploymentName,
+		IsReady:        false,
 	}, nil
 }
 
@@ -75,7 +80,8 @@ func (p *CNDPortForward) Start(c *kubernetes.Clientset, config *rest.Config, pod
 	go func() {
 		select {
 		case <-pf.Ready:
-			log.Printf("Synchronization starting %d -> %d", p.LocalPort, p.RemotePort)
+			log.Infof("Linking '%s' to %s...", p.LocalPath, p.DeploymentName)
+			log.Infof("Ready! Go to your local IDE and continue coding!")
 			p.IsReady = true
 		}
 	}()

--- a/k8/services/services.go
+++ b/k8/services/services.go
@@ -2,8 +2,9 @@ package services
 
 import (
 	"fmt"
-	"log"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,21 +21,21 @@ func Deploy(s *apiv1.Service, namespace string, c *kubernetes.Clientset) error {
 	}
 
 	if sk8.Name == "" {
-		log.Printf("Creating service '%s'...", serviceName)
+		log.Debugf("Creating service '%s'...", serviceName)
 		_, err = sClient.Create(s)
 		if err != nil {
 			return fmt.Errorf("Error creating kubernetes service: %s", err)
 		}
-		log.Printf("Created service '%s'.", serviceName)
+		log.Debugf("Created service '%s'.", serviceName)
 	} else {
-		log.Printf("Updating service '%s'...", serviceName)
+		log.Debugf("Updating service '%s'...", serviceName)
 		s.Spec.ClusterIP = sk8.Spec.ClusterIP
 		s.GetObjectMeta().SetResourceVersion(sk8.GetObjectMeta().GetResourceVersion())
 		_, err = sClient.Update(s)
 		if err != nil {
 			return fmt.Errorf("Error updating kubernetes service: %s", err)
 		}
-		log.Printf("Updated service '%s'.", serviceName)
+		log.Debugf("Updated service '%s'.", serviceName)
 	}
 	return nil
 }

--- a/k8/services/services.go
+++ b/k8/services/services.go
@@ -21,21 +21,21 @@ func Deploy(s *apiv1.Service, namespace string, c *kubernetes.Clientset) error {
 	}
 
 	if sk8.Name == "" {
-		log.Debugf("Creating service '%s'...", serviceName)
+		log.Infof("Creating service '%s'...", serviceName)
 		_, err = sClient.Create(s)
 		if err != nil {
 			return fmt.Errorf("Error creating kubernetes service: %s", err)
 		}
-		log.Debugf("Created service '%s'.", serviceName)
+		log.Infof("Created service '%s'.", serviceName)
 	} else {
-		log.Debugf("Updating service '%s'...", serviceName)
+		log.Infof("Updating service '%s'...", serviceName)
 		s.Spec.ClusterIP = sk8.Spec.ClusterIP
 		s.GetObjectMeta().SetResourceVersion(sk8.GetObjectMeta().GetResourceVersion())
 		_, err = sClient.Update(s)
 		if err != nil {
 			return fmt.Errorf("Error updating kubernetes service: %s", err)
 		}
-		log.Debugf("Updated service '%s'.", serviceName)
+		log.Infof("Updated service '%s'.", serviceName)
 	}
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -1,12 +1,23 @@
 package main
 
 import (
-	"log"
+	"os"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/okteto/cnd/cmd"
 	"github.com/spf13/cobra"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
+
+func init() {
+	// Output to stdout instead of the default stderr
+	// Can be any io.Writer, see below for File example
+	log.SetOutput(os.Stdout)
+
+	// Only log the warning severity or above.
+	log.SetLevel(log.InfoLevel)
+}
 
 func main() {
 	commands := &cobra.Command{
@@ -22,6 +33,6 @@ func main() {
 	)
 
 	if err := commands.Execute(); err != nil {
-		log.Printf("ERROR: %s", err)
+		log.Error(err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/okteto/cnd/cmd"
-	"github.com/spf13/cobra"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
@@ -16,23 +15,9 @@ func init() {
 	log.SetOutput(os.Stdout)
 
 	// Only log the warning severity or above.
-	log.SetLevel(log.InfoLevel)
+	log.SetLevel(log.WarnLevel)
 }
 
 func main() {
-	commands := &cobra.Command{
-		Use:   "cnd COMMAND [ARG...]",
-		Short: "Manage cloud native environments",
-	}
-	commands.AddCommand(
-		cmd.Up(),
-		cmd.Exec(),
-		cmd.Down(),
-		cmd.Rm(),
-		cmd.Version(),
-	)
-
-	if err := commands.Execute(); err != nil {
-		log.Error(err)
-	}
+	cmd.Execute()
 }

--- a/model/deployment.go
+++ b/model/deployment.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"os"
-	"path"
 
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
@@ -20,11 +19,11 @@ type deployment struct {
 
 //Deployment returns a k8 deployment for a cloud native environment
 func (dev *Dev) Deployment() (*appsv1.Deployment, error) {
-	cwd, _ := os.Getwd()
-	file, err := os.Open(path.Join(cwd, dev.Swap.Deployment.File))
+	file, err := os.Open(dev.Swap.Deployment.File)
 	if err != nil {
 		return nil, err
 	}
+
 	dec := k8Yaml.NewYAMLOrJSONDecoder(file, 1000)
 	var d appsv1.Deployment
 	dec.Decode(&d)

--- a/model/dev.go
+++ b/model/dev.go
@@ -95,12 +95,23 @@ func loadDev(b []byte) (*Dev, error) {
 }
 
 func (dev *Dev) fixPath(originalPath string) {
+	wd, _ := os.Getwd()
+
 	if !filepath.IsAbs(dev.Mount.Source) {
 		if filepath.IsAbs(originalPath) {
 			dev.Mount.Source = path.Join(path.Dir(originalPath), dev.Mount.Source)
 		} else {
-			wd, _ := os.Getwd()
+
 			dev.Mount.Source = path.Join(wd, path.Dir(originalPath), dev.Mount.Source)
+		}
+	}
+
+	if !filepath.IsAbs(dev.Swap.Deployment.File) {
+		if filepath.IsAbs(originalPath) {
+			dev.Swap.Deployment.File = path.Join(path.Dir(originalPath), dev.Swap.Deployment.File)
+		} else {
+
+			dev.Swap.Deployment.File = path.Join(wd, path.Dir(originalPath), dev.Swap.Deployment.File)
 		}
 	}
 }

--- a/model/dev_test.go
+++ b/model/dev_test.go
@@ -38,17 +38,19 @@ func TestReadDev(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		dev := Dev{
-			Name: "test",
-			Mount: mount{
-				Source: tt.source,
-				Target: tt.target,
-			},
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			dev := Dev{
+				Name: "test",
+				Mount: mount{
+					Source: tt.source,
+					Target: tt.target,
+				},
+			}
 
-		dev.fixPath(tt.devPath)
-		if dev.Mount.Source != tt.expected {
-			t.Errorf("%s != %s", dev.Mount.Source, tt.expected)
-		}
+			dev.fixPath(tt.devPath)
+			if dev.Mount.Source != tt.expected {
+				t.Errorf("%s != %s", dev.Mount.Source, tt.expected)
+			}
+		})
 	}
 }

--- a/syncthing/syncthing.go
+++ b/syncthing/syncthing.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net"
 	"os"
 	"os/exec"
@@ -14,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+
+	log "github.com/sirupsen/logrus"
 )
 
 var (
@@ -201,7 +202,7 @@ func (s *Syncthing) Run() error {
 		return err
 	}
 
-	log.Printf("Syncthing running on http://%s and tcp://%s", s.GUIAddress, s.ListenAddress)
+	log.Debugf("Syncthing running on http://%s and tcp://%s", s.GUIAddress, s.ListenAddress)
 	return nil
 }
 

--- a/syncthing/syncthing.go
+++ b/syncthing/syncthing.go
@@ -202,7 +202,7 @@ func (s *Syncthing) Run() error {
 		return err
 	}
 
-	log.Debugf("Syncthing running on http://%s and tcp://%s", s.GUIAddress, s.ListenAddress)
+	log.Infof("Syncthing running on http://%s and tcp://%s", s.GUIAddress, s.ListenAddress)
 	return nil
 }
 


### PR DESCRIPTION
By default, we show only the basic messages:

![image](https://user-images.githubusercontent.com/475313/49412709-40a05c00-f722-11e8-9191-8852bacbdb1a.png)


The user can override this wtih the `-l` flag, to get more information:
![image](https://user-images.githubusercontent.com/475313/49412726-4eee7800-f722-11e8-892c-a074d1ad4909.png)

The model I'm following is like this:
- Use fmt.Println() for the messages that should always be displayed (should be very basic, almost following the  "no new is good news principle of linux"
- Use log.X for the rest. By default we only show error, but can be customized by the `l` flag.