### PR TITLE
Use the existing namespace for exec, instead of asking for it

### DIFF
--- a/pkg/k8/deployments/deployments.go
+++ b/pkg/k8/deployments/deployments.go
@@ -308,5 +308,5 @@ func checkForLegacyCND(namespace, deploymentName string, c *kubernetes.Clientset
 		}
 	}
 
-	return fmt.Errorf("cloud native environment is not initialized. Please run 'cnd up' first")
+	return fmt.Errorf("cloud native environment %s/%s is not initialized. Please run 'cnd up' first", namespace, deploymentName)
 }


### PR DESCRIPTION
## Proposed changes
-  `cnd exec` figures out the namespace that was used during `cnd up` instead of asking the user for it
 
