### PR TITLE
Set the container name in dev before saving it during up

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,6 +4,4 @@
 *       @okteto
 * See https://blog.github.com/2017-07-06-introducing-code-owners/ for details
 
-*       @pchico83
-*       @rberrelleza
-*       @rlamana
+*       @pchico83 @rberrelleza @rlamana

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -52,6 +52,8 @@ func executeUp(devPath string) error {
 		return err
 	}
 
+	dev.Swap.Deployment.Container = deployments.GetDevContainerOrFirst(dev.Swap.Deployment.Container, pod.Spec.Containers)
+
 	if err := deployments.InitVolumeWithTarball(client, restConfig, namespace, pod.Name, dev.Mount.Source); err != nil {
 		return err
 	}

--- a/pkg/k8/deployments/utils.go
+++ b/pkg/k8/deployments/utils.go
@@ -3,6 +3,7 @@ package deployments
 import (
 	"fmt"
 
+	"github.com/okteto/cnd/pkg/model"
 	log "github.com/sirupsen/logrus"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -73,4 +74,17 @@ func setAnnotation(o metav1.Object, key, value string) {
 	}
 	annotations[key] = value
 	o.SetAnnotations(annotations)
+}
+
+// GetDevContainerOrFirst returns the named container or the first user-defined one
+func GetDevContainerOrFirst(container string, containers []apiv1.Container) string {
+	if container == "" {
+		for _, c := range containers {
+			if c.Name != model.CNDSyncContainerName {
+				container = c.Name
+			}
+		}
+	}
+
+	return container
 }

--- a/pkg/k8/exec/exec.go
+++ b/pkg/k8/exec/exec.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/client-go/util/exec"
 	"k8s.io/kubernetes/pkg/kubectl/util/term"
 
-	"github.com/okteto/cnd/pkg/model"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -26,14 +25,6 @@ func Exec(c *kubernetes.Clientset, config *rest.Config, pod *apiv1.Pod, containe
 	}
 
 	sizeQueue := t.MonitorSize(t.GetSize())
-
-	if container == "" {
-		for _, c := range pod.Spec.Containers {
-			if c.Name != model.CNDSyncContainerName {
-				container = c.Name
-			}
-		}
-	}
 
 	req := c.CoreV1().RESTClient().Post().
 		Namespace(pod.Namespace).

--- a/pkg/k8/forward/forward.go
+++ b/pkg/k8/forward/forward.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/okteto/cnd/pkg/k8/logs"
+	log "github.com/sirupsen/logrus"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -84,7 +85,9 @@ func (p *CNDPortForward) Start(c *kubernetes.Clientset, config *rest.Config, pod
 			fmt.Printf("Ready! Go to your local IDE and continue coding!")
 			fmt.Println()
 			p.IsReady = true
-			logs.Logs(c, config, pod, container)
+			if err := logs.Logs(c, config, pod, container); err != nil {
+				log.Errorf("couldn't retrieve logs for container: %s: %s", container, err)
+			}
 		}
 	}()
 

--- a/pkg/k8/forward/forward.go
+++ b/pkg/k8/forward/forward.go
@@ -86,7 +86,7 @@ func (p *CNDPortForward) Start(c *kubernetes.Clientset, config *rest.Config, pod
 			fmt.Println()
 			p.IsReady = true
 			if err := logs.Logs(c, config, pod, container); err != nil {
-				log.Errorf("couldn't retrieve logs for container: %s: %s", container, err)
+				log.Errorf("couldn't retrieve logs for %s/%s: %s", pod.Namespace, container, err)
 			}
 		}
 	}()


### PR DESCRIPTION
Fixes #103 

## Proposed changes
- On `cnd up`, store the container name in the `~/.cnd/.state` file.  This will be the one determined by `cnd.yml` or the first one in the pod if empty
-  `cnd exec` and `cnd run` will run on the container used by `cnd up`, independently of the value on `cnd.yml`.
