### PR TITLE
update the formula to build with go instead of downloading the binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - deploy:
           name: "Update brew formula"
           command: |
-            bash ./update_homebrew_formula.sh 0.0.1 $(awk {'print $1'} ./artifacts/bin/cnd-darwin-amd64.sha256) ${GITHUB_TOKEN} 1
+            bash ./update_homebrew_formula.sh 0.0.1 $CIRCLE_SHA1 $GITHUB_TOKEN 1
   publish-github-release:
     docker:
       - image: cibuilds/github:0.10
@@ -48,11 +48,11 @@ jobs:
       - run:
           name: "Publish Release on GitHub"
           command: |
-            ghr -u okteto -r cnd -c ${CIRCLE_SHA1} -token ${GITHUB_TOKEN} -replace -prerelease $CIRCLE_TAG  ./artifacts/bin/
+            ghr -u okteto -r cnd -c $CIRCLE_SHA1 -token $GITHUB_TOKEN -replace -prerelease $CIRCLE_TAG  ./artifacts/bin/
       - deploy:
           name: "Update brew formula"
           command: |
-            bash ./update_homebrew_formula.sh ${CIRCLE_TAG} $(awk {'print $1'} ./artifacts/bin/cnd-darwin-amd64.sha256) ${GITHUB_TOKEN} 0
+            bash ./update_homebrew_formula.sh $CIRCLE_TAG $CIRCLE_SHA1 $GITHUB_TOKEN 0
 
 workflows:
   version: 2

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,7 +26,7 @@ go get github.com/okteto/cnd
 
 You can get also get a prebuilt binary [from our releases page](https://github.com/okteto/cnd/releases/latest)
 
-## Upgrade
+# Upgrade
 
 ## Homebrew
 Upgrade to the latest stable version by executing:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,6 +7,12 @@ brew tap okteto/cnd
 brew install cnd
 ```
 
+You can install to the latest unstable version by executing:
+```console
+brew tap okteto/cnd
+brew install --HEAD cnd
+```
+
 ## Manual install
 
 The synching functionality of **cnd** is provided by [syncthing](https://docs.syncthing.net).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,8 +18,26 @@ To install `syncthing`, download the corresponding binary from their [releases p
 which syncthing
 ```
 
-Install **cnd** from by executing:
+Install **cnd** from source by executing:
 
 ```console
 go get github.com/okteto/cnd
 ```
+
+You can get also get a prebuilt binary [from our releases page](https://github.com/okteto/cnd/releases/latest)
+
+## Upgrade
+
+## Homebrew
+Upgrade to the latest stable version by executing:
+```console
+brew upgrade cnd
+```
+
+Upgrade to the latest unstable version by executing:
+```console
+brew upgrade --HEAD cnd
+```
+
+## Manually 
+You can get our latest available binary [from our releases page](https://github.com/okteto/cnd/releases/latest). 


### PR DESCRIPTION

## Proposed changes
-  Instead of downloading the built artifact the formula will now build the binary on install and upgrade directly on the user's machine. This allows to install the latest from master (by running `brew upgrade --HEAD cnd) or the 'stable' (brew upgrade cnd). This is also aligned with the recommendations issued by homebrew for when we want to be included in the main formula list

