### PR TITLE
Only specify namespace in cnd up

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -15,20 +15,22 @@ import (
 
 //Create automatically generates the manifest
 func Create() *cobra.Command {
+	var devPath string
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Automatically create the cnd manifest file",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return executeCreate()
+			return executeCreate(devPath)
 		},
 	}
 
+	addDevPathFlag(cmd, &devPath)
 	return cmd
 }
 
-func executeCreate() error {
-	if fileExists(c.devPath) {
-		return fmt.Errorf("%s already exists. Please delete it before running the command again", c.devPath)
+func executeCreate(devPath string) error {
+	if fileExists(devPath) {
+		return fmt.Errorf("%s already exists. Please delete it before running the command again", devPath)
 	}
 
 	root, err := os.Getwd()
@@ -50,7 +52,7 @@ func executeCreate() error {
 		return fmt.Errorf("Failed to generate your cnd manifest")
 	}
 
-	if err := ioutil.WriteFile(c.devPath, marshalled, 0600); err != nil {
+	if err := ioutil.WriteFile(devPath, marshalled, 0600); err != nil {
 		log.Error(err)
 		return fmt.Errorf("Failed to generate your cnd manifest")
 	}
@@ -66,7 +68,7 @@ func fileExists(name string) bool {
 	}
 
 	if err != nil {
-		log.Infof("Failed to check if %s exists: %s", c.devPath, err)
+		log.Infof("Failed to check if %s exists: %s", name, err)
 	}
 
 	return true

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -17,14 +17,14 @@ func Down() *cobra.Command {
 		Use:   "down",
 		Short: "Deactivate your cloud native development environment",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return executeDown(c.devPath)
+			return executeDown()
 		},
 	}
 
 	return cmd
 }
 
-func executeDown(devPath string) error {
+func executeDown() error {
 	fmt.Println("Deactivating your cloud native development environment...")
 
 	namespace, deployment, _, err := findDevEnvironment(false)
@@ -39,7 +39,7 @@ func executeDown(devPath string) error {
 		return fmt.Errorf("failed to deactivate your cloud native environment")
 	}
 
-	_, client, _, err := getKubernetesClient()
+	_, client, _, err := getKubernetesClient(namespace)
 	if err != nil {
 		return err
 	}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -14,6 +14,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	errNoCNDEnvironment = fmt.Errorf("There aren't any cloud native development environments active in your current folder")
+)
+
 //Exec executes a command on the CND container
 func Exec() *cobra.Command {
 	cmd := &cobra.Command{
@@ -72,8 +76,9 @@ func findDevEnvironment() (string, string, string, error) {
 	}
 
 	if len(candidates) == 0 {
-		return "", "", "", fmt.Errorf("There aren't any cloud native development environments active in your current folder")
+		return "", "", "", errNoCNDEnvironment
 	}
+
 	if len(candidates) > 1 {
 		fmt.Printf("warning: there are %d cloud native development environments active in your current folder, using '%s'\n", len(candidates), deploymentFullName)
 	}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -40,8 +40,11 @@ func Exec() *cobra.Command {
 
 func executeExec(args []string) error {
 	namespace, deployment, devContainer, err := findDevEnvironment(true)
+	if err != nil {
+		return err
+	}
 
-	_, client, config, err := getKubernetesClient()
+	_, client, config, err := getKubernetesClient(namespace)
 	if err != nil {
 		return err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,9 +11,7 @@ import (
 )
 
 type config struct {
-	logLevel  string
-	devPath   string
-	namespace string
+	logLevel string
 }
 
 var (
@@ -34,8 +32,6 @@ var (
 
 func init() {
 	root.PersistentFlags().StringVarP(&c.logLevel, "loglevel", "l", "warn", "amount of information outputted (debug, info, warn, error)")
-	root.PersistentFlags().StringVarP(&c.devPath, "file", "f", "cnd.yml", "path to the cnd manifest file")
-	root.PersistentFlags().StringVarP(&c.namespace, "namespace", "n", "", "kubernetes namespace to use (defaults to the current kube config namespace)")
 	root.AddCommand(
 		Up(),
 		Exec(),
@@ -54,6 +50,10 @@ func Execute() {
 	}
 }
 
-func getKubernetesClient() (string, *kubernetes.Clientset, *rest.Config, error) {
-	return client.Get(c.namespace)
+func getKubernetesClient(namespace string) (string, *kubernetes.Clientset, *rest.Config, error) {
+	return client.Get(namespace)
+}
+
+func addDevPathFlag(cmd *cobra.Command, devPath *string) {
+	cmd.Flags().StringVarP(devPath, "file", "f", "cnd.yml", "path to the cnd manifest file")
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -11,11 +11,12 @@ import (
 
 //Run executes a custom command on the CND container
 func Run() *cobra.Command {
+	var devPath string
 	cmd := &cobra.Command{
 		Use:   "run SCRIPT ARGS",
 		Short: "Run a script defined in your cnd.yml file directly in your cloud native environment",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return executeRun(args)
+			return executeRun(devPath, args)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 || args[0] == "" {
@@ -26,11 +27,12 @@ func Run() *cobra.Command {
 		},
 	}
 
+	addDevPathFlag(cmd, &devPath)
 	return cmd
 }
 
-func executeRun(args []string) error {
-	dev, err := model.ReadDev(c.devPath)
+func executeRun(devPath string, args []string) error {
+	dev, err := model.ReadDev(devPath)
 	if err != nil {
 		return err
 	}
@@ -39,7 +41,7 @@ func executeRun(args []string) error {
 		return executeExec(parseArguments(val, args))
 	}
 
-	return fmt.Errorf("%s is not defined in %s", args[0], c.devPath)
+	return fmt.Errorf("%s is not defined in %s", args[0], devPath)
 
 }
 

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -43,7 +43,7 @@ func executeUp(devPath, namespace string) error {
 		return fmt.Errorf("there is already an entry for %s. Are you running 'cnd up' somewhere else?", deployments.GetFullName(namespace, deploymentName))
 	}
 
-	_, client, restConfig, err := getKubernetesClient(namespace)
+	namespace, client, restConfig, err := getKubernetesClient(namespace)
 	if err != nil {
 		return err
 	}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -18,28 +18,32 @@ import (
 
 //Up starts a cloud native environment
 func Up() *cobra.Command {
+	var namespace string
+	var devPath string
 	cmd := &cobra.Command{
 		Use:   "up",
 		Short: "Activate your cloud native development environment",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return executeUp(c.devPath)
+			return executeUp(devPath, namespace)
 		},
 	}
 
+	addDevPathFlag(cmd, &devPath)
+	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "kubernetes namespace to use (defaults to the current kube config namespace)")
 	return cmd
 }
 
-func executeUp(devPath string) error {
+func executeUp(devPath, namespace string) error {
 	fmt.Println("Activating your cloud native development environment...")
 
-	namespace, deploymentName, _, err := findDevEnvironment(true)
+	_, deploymentName, _, err := findDevEnvironment(true)
 
 	if err != errNoCNDEnvironment {
 		log.Info(err)
 		return fmt.Errorf("there is already an entry for %s. Are you running 'cnd up' somewhere else?", deployments.GetFullName(namespace, deploymentName))
 	}
 
-	namespace, client, restConfig, err := getKubernetesClient()
+	_, client, restConfig, err := getKubernetesClient(namespace)
 	if err != nil {
 		return err
 	}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -32,6 +32,11 @@ func Up() *cobra.Command {
 func executeUp(devPath string) error {
 	fmt.Println("Activating your cloud native development environment...")
 
+	namespace, deploymentName, _, err := findDevEnvironment()
+	if err != errNoCNDEnvironment {
+		return fmt.Errorf("there is already an entry for %s. Are you running 'cnd up' somewhere else?", deployments.GetFullName(namespace, deploymentName))
+	}
+
 	namespace, client, restConfig, err := getKubernetesClient()
 	if err != nil {
 		return err

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -32,8 +32,10 @@ func Up() *cobra.Command {
 func executeUp(devPath string) error {
 	fmt.Println("Activating your cloud native development environment...")
 
-	namespace, deploymentName, _, err := findDevEnvironment()
+	namespace, deploymentName, _, err := findDevEnvironment(true)
+
 	if err != errNoCNDEnvironment {
+		log.Info(err)
 		return fmt.Errorf("there is already an entry for %s. Are you running 'cnd up' somewhere else?", deployments.GetFullName(namespace, deploymentName))
 	}
 
@@ -104,7 +106,7 @@ func stop(sy *syncthing.Syncthing, pf *forward.CNDPortForward) {
 		log.Error(err)
 	}
 
-	storage.Delete(sy.Namespace, sy.Name)
+	storage.Stop(sy.Namespace, sy.Name)
 	pf.Stop()
 	log.Debugf("stopped syncthing and port forwarding")
 }

--- a/pkg/k8/deployments/deployments.go
+++ b/pkg/k8/deployments/deployments.go
@@ -20,6 +20,10 @@ import (
 //DevModeOn activates a cloud native development for a given k8 deployment
 func DevModeOn(dev *model.Dev, namespace string, c *kubernetes.Clientset) (string, error) {
 	d, err := loadDeployment(namespace, dev.Swap.Deployment.Name, c)
+	if err != nil {
+		return "", err
+	}
+
 	dev.Swap.Deployment.Container = getDevContainerOrFirst(dev.Swap.Deployment.Container, d.Spec.Template.Spec.Containers)
 
 	if err != nil {

--- a/pkg/k8/deployments/deployments.go
+++ b/pkg/k8/deployments/deployments.go
@@ -49,8 +49,8 @@ func DevModeOn(dev *model.Dev, namespace string, c *kubernetes.Clientset) (strin
 }
 
 //DevModeOff deactivates a cloud native development
-func DevModeOff(dev *model.Dev, namespace string, c *kubernetes.Clientset) (string, error) {
-	d, err := loadDeployment(namespace, dev.Swap.Deployment.Name, c)
+func DevModeOff(namespace, deploymentName string, c *kubernetes.Clientset) (string, error) {
+	d, err := loadDeployment(namespace, deploymentName, c)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -73,6 +73,10 @@ func Insert(namespace, deployment, container, folder, host string) error {
 			return nil
 		}
 
+		if svc2.Syncthing == "" {
+			return nil
+		}
+
 		return ErrAlreadyRunning
 	}
 
@@ -93,6 +97,20 @@ func Get(namespace, deployment string) (*Service, error) {
 		return nil, fmt.Errorf("there aren't any active cloud native development environments available for '%s'", fullName)
 	}
 	return &svc, nil
+}
+
+//Stop marks a service entry as stopped
+func Stop(namespace, deployment string) error {
+	s, err := load()
+	if err != nil {
+		return err
+	}
+
+	fullName := fmt.Sprintf("%s/%s", namespace, deployment)
+	svc := s.Services[fullName]
+	svc.Syncthing = ""
+	s.Services[fullName] = svc
+	return s.save()
 }
 
 //Delete deletes a service entry


### PR DESCRIPTION
## Proposed changes
- Only specify namespace in cnd up. We can store this in the state, and then all the other commands  can use it from there.  This has the extra benefit that it ensures that the command will only be executed on the same namespace\deployment that was used for cnd up, even if cnd.yml change after it.

