### PR TITLE
Delete the folder under .cnd/namespace on down

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -61,6 +61,11 @@ func executeDown() error {
 		return err
 	}
 
+	err = syncthing.RemoveFolder()
+	if err != nil {
+		return err
+	}
+
 	fmt.Println("Cloud native development environment deactivated")
 	return nil
 }


### PR DESCRIPTION
## Proposed changes
- On `cnd down` delete the folder under ~/.cnd/$NAMESPACE/$NAME. This helps remove stale files, and also work around syncthing-related file synchronization issues 
