### PR TITLE
Keep .state keys based on container names

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -27,7 +27,7 @@ func Down() *cobra.Command {
 func executeDown() error {
 	fmt.Println("Deactivating your cloud native development environment...")
 
-	namespace, deployment, _, err := findDevEnvironment(false)
+	namespace, deployment, devContainer, err := findDevEnvironment(false)
 
 	if err != nil {
 		if err == errNoCNDEnvironment {
@@ -44,17 +44,17 @@ func executeDown() error {
 		return err
 	}
 
-	name, err := deployments.DevModeOff(namespace, deployment, client)
+	_, err = deployments.DevModeOff(namespace, deployment, client)
 	if err != nil {
 		return err
 	}
 
-	syncthing, err := syncthing.NewSyncthing(name, namespace, "")
+	syncthing, err := syncthing.NewSyncthing(deployment, namespace, devContainer, "")
 	if err != nil {
 		return err
 	}
 
-	storage.Delete(namespace, name)
+	storage.Delete(namespace, deployment, devContainer)
 
 	err = syncthing.Stop()
 	if err != nil {

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -62,7 +62,6 @@ func findDevEnvironment(mustBeRunning bool) (string, string, string, error) {
 	services := storage.All()
 	candidates := []storage.Service{}
 	deploymentFullName := ""
-	devContainer := ""
 	folder, _ := os.Getwd()
 
 	for name, svc := range services {
@@ -74,7 +73,6 @@ func findDevEnvironment(mustBeRunning bool) (string, string, string, error) {
 			candidates = append(candidates, svc)
 			if deploymentFullName == "" {
 				deploymentFullName = name
-				devContainer = svc.Container
 			}
 		}
 	}
@@ -87,9 +85,10 @@ func findDevEnvironment(mustBeRunning bool) (string, string, string, error) {
 		fmt.Printf("warning: there are %d cloud native development environments active in your current folder, using '%s'\n", len(candidates), deploymentFullName)
 	}
 
-	parts := strings.SplitN(deploymentFullName, "/", 2)
+	parts := strings.SplitN(deploymentFullName, "/", 3)
 	namespace := parts[0]
 	deploymentName := parts[1]
+	devContainer := parts[2]
 
 	return namespace, deploymentName, devContainer, nil
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -67,7 +67,7 @@ func executeUp(devPath, namespace string) error {
 		return err
 	}
 
-	sy, err := syncthing.NewSyncthing(name, namespace, dev.Mount.Source)
+	sy, err := syncthing.NewSyncthing(name, namespace, dev.Swap.Deployment.Container, dev.Mount.Source)
 	if err != nil {
 		return err
 	}
@@ -110,7 +110,7 @@ func stop(sy *syncthing.Syncthing, pf *forward.CNDPortForward) {
 		log.Error(err)
 	}
 
-	storage.Stop(sy.Namespace, sy.Name)
+	storage.Stop(sy.Namespace, sy.Name, sy.Container)
 	pf.Stop()
 	log.Debugf("stopped syncthing and port forwarding")
 }

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -19,7 +19,7 @@ func TestInsertGetListDelete(t *testing.T) {
 	if len(services) != 0 {
 		t.Fatalf("1 listing should be empty: %d", len(services))
 	}
-	err = Insert("project1", "service1", "dev", "/folder1", "localhost1")
+	err = Insert("project1", "service1", "dev1", "/folder1", "localhost1")
 	if err != nil {
 		t.Fatalf("error 1 inserting: %s", err)
 	}
@@ -27,7 +27,7 @@ func TestInsertGetListDelete(t *testing.T) {
 	if len(services) != 1 {
 		t.Fatalf("2 listing should be 1: %d", len(services))
 	}
-	err = Insert("project2", "service2", "dev", "/folder2", "localhost2")
+	err = Insert("project2", "service2", "dev2", "/folder2", "localhost2")
 	if err != nil {
 		t.Fatalf("error 1 inserting: %s", err)
 	}
@@ -35,7 +35,7 @@ func TestInsertGetListDelete(t *testing.T) {
 	if len(services) != 2 {
 		t.Fatalf("3 listing should be 2: %d", len(services))
 	}
-	svc := services["project1/service1"]
+	svc := services["project1/service1/dev1"]
 	if err != nil {
 		t.Fatalf("error getting service: %s", err)
 	}
@@ -47,11 +47,7 @@ func TestInsertGetListDelete(t *testing.T) {
 		t.Fatalf("wrong host: %s", svc.Syncthing)
 	}
 
-	if svc.Container != "dev" {
-		t.Fatalf("wrong container: %s", svc.Container)
-	}
-
-	err = Delete("project1", "service1")
+	err = Delete("project1", "service1", "dev1")
 	if err != nil {
 		t.Fatalf("error deleting service: %s", err)
 	}

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -43,6 +43,7 @@ type Syncthing struct {
 	home             string
 	Name             string
 	Namespace        string
+	Container        string
 	LocalPath        string
 	RemoteAddress    string
 	RemoteDeviceID   string
@@ -57,7 +58,7 @@ func getCNDHome() string {
 }
 
 // NewSyncthing constructs a new Syncthing.
-func NewSyncthing(name, namespace, localPath string) (*Syncthing, error) {
+func NewSyncthing(name, namespace, container, localPath string) (*Syncthing, error) {
 
 	remotePort, err := getAvailablePort()
 	if err != nil {
@@ -79,6 +80,7 @@ func NewSyncthing(name, namespace, localPath string) (*Syncthing, error) {
 		binPath:          "syncthing",
 		Name:             name,
 		Namespace:        namespace,
+		Container:        container,
 		home:             path.Join(getCNDHome(), namespace, name),
 		LocalPath:        localPath,
 		RemoteAddress:    fmt.Sprintf("tcp://localhost:%d", remotePort),


### PR DESCRIPTION
## Proposed changes
- Keep the local cnd state based on namespace + deployment + container name to allow multiple "cnd up" to the same deployment at the same time in a following PR.
