### PR TITLE
Retry log streaming connection if it breaks

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -56,12 +56,8 @@ func executeExec(args []string) error {
 	if err != nil {
 		return err
 	}
-	dev, err := deployments.GetDevFromAnnotation(d)
-	if err != nil {
-		return err
-	}
 
-	pod, err := deployments.GetCNDPod(dev, d, client)
+	pod, err := deployments.GetCNDPod(d, client)
 	if err != nil {
 		return err
 	}

--- a/pkg/k8/deployments/deployments.go
+++ b/pkg/k8/deployments/deployments.go
@@ -99,7 +99,7 @@ func deploy(d *appsv1.Deployment, c *kubernetes.Clientset) error {
 }
 
 // GetCNDPod returns the pod that has the cnd containers
-func GetCNDPod(dev *model.Dev, d *appsv1.Deployment, c *kubernetes.Clientset) (*apiv1.Pod, error) {
+func GetCNDPod(d *appsv1.Deployment, c *kubernetes.Clientset) (*apiv1.Pod, error) {
 	tries := 0
 	for tries < 30 {
 
@@ -121,9 +121,6 @@ func GetCNDPod(dev *model.Dev, d *appsv1.Deployment, c *kubernetes.Clientset) (*
 		}
 
 		if len(pendingOrRunningPods) == 1 {
-			if !isContainerInPod(&pendingOrRunningPods[0], dev.Swap.Deployment.Container) {
-				return nil, fmt.Errorf("container %s doesn't exist in the pod", dev.Swap.Deployment.Container)
-			}
 			return &pendingOrRunningPods[0], nil
 		}
 

--- a/pkg/k8/deployments/utils.go
+++ b/pkg/k8/deployments/utils.go
@@ -16,16 +16,6 @@ func GetFullName(namespace, deploymentName string) string {
 	return fmt.Sprintf("%s/%s", namespace, deploymentName)
 }
 
-func isContainerInPod(pod *apiv1.Pod, container string) bool {
-	for _, c := range pod.Spec.Containers {
-		if c.Name == container {
-			return true
-		}
-	}
-
-	return false
-}
-
 func getLabel(o metav1.Object, key string) string {
 	labels := o.GetLabels()
 	if labels != nil {

--- a/pkg/k8/logs/logs.go
+++ b/pkg/k8/logs/logs.go
@@ -3,30 +3,68 @@ package logs
 import (
 	"io"
 	"os"
+	"os/signal"
+	"sync"
+	"time"
 
+	log "github.com/sirupsen/logrus"
+
+	"github.com/okteto/cnd/pkg/k8/deployments"
+	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
-//Logs stremas logs from a container
-func Logs(c *kubernetes.Clientset, config *rest.Config, pod *apiv1.Pod, container string) error {
-	var tailLines int64
-	tailLines = 100
-	req := c.CoreV1().Pods(pod.Namespace).GetLogs(
-		pod.Name,
-		&apiv1.PodLogOptions{
-			Container:  container,
-			Timestamps: true,
-			Follow:     true,
-			TailLines:  &tailLines,
-		},
-	)
-	readCloser, err := req.Stream()
-	if err != nil {
-		return err
+//StreamLogs stremas logs from a container
+func StreamLogs(d *appsv1.Deployment, container string, c *kubernetes.Clientset, config *rest.Config, wg *sync.WaitGroup) {
+	defer wg.Done()
+	var readCloser io.ReadCloser
+	end := false
+
+	channel := make(chan os.Signal, 1)
+	signal.Notify(channel, os.Interrupt)
+	go func() {
+		<-channel
+		if readCloser != nil {
+			readCloser.Close()
+		}
+		end = true
+	}()
+
+	var wait time.Duration
+	for !end {
+		time.Sleep(wait * time.Second)
+		pod, err := deployments.GetCNDPod(d, c)
+		if err != nil {
+			if wait < 10 {
+				wait++
+			}
+			continue
+		}
+		var tailLines int64
+		tailLines = 100
+		req := c.CoreV1().Pods(pod.Namespace).GetLogs(
+			pod.Name,
+			&apiv1.PodLogOptions{
+				Container:  container,
+				Timestamps: true,
+				Follow:     true,
+				TailLines:  &tailLines,
+			},
+		)
+		readCloser, err = req.Stream()
+		if err != nil {
+			if wait < 10 {
+				wait++
+			}
+			continue
+		}
+		wait = 0
+		if _, err = io.Copy(os.Stdout, readCloser); err != nil {
+			log.Errorf("couldn't retrieve logs for %s/%s: %s", pod.Namespace, container, err)
+		}
+		readCloser = nil
 	}
-	defer readCloser.Close()
-	_, err = io.Copy(os.Stdout, readCloser)
-	return err
+	return
 }


### PR DESCRIPTION
Fixes: stream logs stop working if pod is restarted

## Proposed changes
- Retry streaming logs connection
- Use waiting groups to handle the end of the program.
