### PR TITLE
CND crashes when creating a file for python

### DIFF
--- a/pkg/linguist/dev.go
+++ b/pkg/linguist/dev.go
@@ -67,6 +67,11 @@ func GetDevConfig(language string) *model.Dev {
 	dev.Mount.Source = "."
 	dev.Mount.Target = vals.path
 	dev.Scripts = vals.scripts
+
+	if dev.Scripts == nil {
+		dev.Scripts = make(map[string]string)
+	}
+
 	dev.Scripts[helloCommandName] = "echo Your cluster ♥ you"
 	return dev
 }


### PR DESCRIPTION
## Proposed changes
- Initialize the scripts dictionary, which is `nil` if there aren't any scripts declared.
