### PR TITLE
Pip install by default

### DIFF
--- a/pkg/linguist/dev.go
+++ b/pkg/linguist/dev.go
@@ -46,7 +46,7 @@ func init() {
 
 	languageDefaults[python] = languageDefault{
 		image:   "python",
-		command: []string{"sh", "-c", "pip install requirements.txt && python app.py"},
+		command: []string{"sh", "-c", "pip install -r requirements.txt && python app.py"},
 		path:    "/usr/src/app",
 	}
 

--- a/pkg/linguist/dev.go
+++ b/pkg/linguist/dev.go
@@ -46,7 +46,7 @@ func init() {
 
 	languageDefaults[python] = languageDefault{
 		image:   "python",
-		command: []string{"python", "app.py"},
+		command: []string{"sh", "-c", "pip install requirements.txt && python app.py"},
 		path:    "/usr/src/app",
 	}
 


### PR DESCRIPTION
## Proposed changes
- Run pip install as part of the default command for python apps 