### PR TITLE
Don't append volume if one with the same name is already present

### DIFF
--- a/pkg/k8/deployments/translate.go
+++ b/pkg/k8/deployments/translate.go
@@ -165,8 +165,13 @@ func createSyncthingVolume(d *appsv1.Deployment, dev *model.Dev) {
 		d.Spec.Template.Spec.Volumes = []apiv1.Volume{}
 	}
 
-	syncVolume := apiv1.Volume{Name: dev.GetCNDSyncVolume()}
+	for _, v := range d.Spec.Template.Spec.Volumes {
+		if v.Name == dev.GetCNDSyncVolume() {
+			return
+		}
+	}
 
+	syncVolume := apiv1.Volume{Name: dev.GetCNDSyncVolume()}
 	d.Spec.Template.Spec.Volumes = append(
 		d.Spec.Template.Spec.Volumes,
 		syncVolume,


### PR DESCRIPTION
This enables two scenarios:
- define the volume type/size/driver without us having to implement nothing in cnd.
- share the volume with other containers in the same pod (useful for running docker compose commands)