### PR TITLE
Allow for custom kubectl instead of the default

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,7 +87,8 @@ func Execute() {
 func GetKubernetesClient(namespace string) (string, *kubernetes.Clientset, *rest.Config, error) {
 	kubePath := path.Join(config.GetCNDHome(), "kubeconfig")
 	if _, err := os.Stat(kubePath); os.IsNotExist(err) {
-		return client.Get(namespace, "")
+		defaultConfigPath := path.Join(os.Getenv("HOME"), ".kube/config")
+		return client.Get(namespace, defaultConfigPath)
 	}
 
 	return client.Get(namespace, kubePath)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,7 +85,7 @@ func Execute() {
 
 // GetKubernetesClient returns the configured kubernetes client for the specified namespace, or the default if empty
 func GetKubernetesClient(namespace string) (string, *kubernetes.Clientset, *rest.Config, error) {
-	kubePath := path.Join(config.GetCNDHome(), ".kubeconfig")
+	kubePath := path.Join(config.GetCNDHome(), "kubeconfig")
 	if _, err := os.Stat(kubePath); os.IsNotExist(err) {
 		return client.Get(namespace, "")
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path"
 	"sync"
 
 	"github.com/okteto/cnd/pkg/analytics"
@@ -84,7 +85,12 @@ func Execute() {
 
 // GetKubernetesClient returns the configured kubernetes client for the specified namespace, or the default if empty
 func GetKubernetesClient(namespace string) (string, *kubernetes.Clientset, *rest.Config, error) {
-	return client.Get(namespace)
+	kubePath := path.Join(config.GetCNDHome(), ".kubeconfig")
+	if _, err := os.Stat(kubePath); os.IsNotExist(err) {
+		return client.Get(namespace, "")
+	}
+
+	return client.Get(namespace, kubePath)
 }
 
 func addDevPathFlag(cmd *cobra.Command, devPath *string) {

--- a/pkg/k8/client/client.go
+++ b/pkg/k8/client/client.go
@@ -1,9 +1,6 @@
 package client
 
 import (
-	"os"
-	"path"
-
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -15,10 +12,6 @@ import (
 // If namespace is empty, it will use the default namespace configured.
 // If path is empty, it will use the default path configuration
 func Get(namespace, configPath string) (string, *kubernetes.Clientset, *rest.Config, error) {
-	if configPath == "" {
-		configPath = path.Join(os.Getenv("HOME"), ".kube/config")
-	}
-
 	log.Debugf("reading kubernetes configuration from %s", configPath)
 
 	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(

--- a/pkg/k8/client/client.go
+++ b/pkg/k8/client/client.go
@@ -4,17 +4,25 @@ import (
 	"os"
 	"path"
 
+	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
-//Get returns a kubernetes client. If namespace is empty, it will use the default namespace configured.
-func Get(namespace string) (string, *kubernetes.Clientset, *rest.Config, error) {
-	home := os.Getenv("HOME")
+//Get returns a kubernetes client.
+// If namespace is empty, it will use the default namespace configured.
+// If path is empty, it will use the default path configuration
+func Get(namespace, configPath string) (string, *kubernetes.Clientset, *rest.Config, error) {
+	if configPath == "" {
+		configPath = path.Join(os.Getenv("HOME"), ".kube/config")
+	}
+
+	log.Debugf("reading kubernetes configuration from %s", configPath)
+
 	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: path.Join(home, ".kube/config")},
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: configPath},
 		&clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: ""}})
 
 	if namespace == "" {

--- a/pkg/k8/logs/logs.go
+++ b/pkg/k8/logs/logs.go
@@ -20,7 +20,9 @@ func StreamLogs(ctx context.Context, wg *sync.WaitGroup, d *appsv1.Deployment, c
 	defer wg.Done()
 	for {
 		if err := streamLogs(ctx, d, container, c); err != nil {
-			log.Infof("couldn't stream logs for %s/%s: %s", d.Name, container, err)
+			if err != context.Canceled {
+				log.Infof("couldn't stream logs for %s/%s: %s", d.Name, container, err)
+			}
 		}
 		select {
 		case <-ctx.Done():

--- a/update_homebrew_formula.sh
+++ b/update_homebrew_formula.sh
@@ -47,7 +47,6 @@ class Cnd < Formula
         system "make"
         bin.install "bin/cnd"
       end
-      mkdir_p "#{ENV["home"}/.cnd"
     end
 
     # Homebrew requires tests.

--- a/update_homebrew_formula.sh
+++ b/update_homebrew_formula.sh
@@ -47,6 +47,7 @@ class Cnd < Formula
         system "make"
         bin.install "bin/cnd"
       end
+      mkdir_p "#{ENV["home"}/.cnd"
     end
 
     # Homebrew requires tests.


### PR DESCRIPTION
## Proposed changes
- This is to allows the user to create a `~/.cnd/kubeconfig` file to try cnd without having to mess up the existing configuration

What do you think of this approach? Another option would be to follow `kubectl` example and have a `--kubeconfig` global parameter to allow specifying the kubectl to use. I prefer the one in the PR just because  once set, then the user doesn't have to remember again. 

We could even do both (`--kubeconfig`, if empty do`~/.cnd/kubeconfig` and if empty do `.kube/config`) but it might be overkill.
