### PR TITLE
Add missing counter increase

### DIFF
--- a/images/init-syncthing/run.sh
+++ b/images/init-syncthing/run.sh
@@ -11,6 +11,7 @@ echo "Waiting for tarball to be uploaded..."
 i=0
 while [ ! -f /initialized ] && [ "$i" -lt 60 ]; do
 	sleep 1
+	i=$(($i+1))
 done
 
 if [ "$i" -eq 60 ]; then

--- a/pkg/k8/deployments/translate.go
+++ b/pkg/k8/deployments/translate.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	cndEnvNamespace  = "CND_KUBERNETES_NAMESPACE"
-	initSyncImageTag = "okteto/init-syncthing:0.4.0"
+	initSyncImageTag = "okteto/init-syncthing:0.4.1"
 	syncImageTag     = "okteto/syncthing:0.4.0"
 )
 


### PR DESCRIPTION
## Proposed changes
- cnd-init container doesn't time out due to a missing counter increase in run.sh 

