### PR TITLE
remove unncesary channels and syncGroup calls

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -65,13 +65,15 @@ func Insert(
 	ctx context.Context, wg *sync.WaitGroup,
 	namespace string, dev *model.Dev, host string) error {
 
-	defer wg.Done()
-
 	if err := insert(namespace, dev, host); err != nil {
 		return err
 	}
 
+	wg.Add(1)
+
 	go func() {
+		defer wg.Done()
+
 		<-ctx.Done()
 		if err := Stop(namespace, dev); err != nil {
 			log.Error(err)

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -175,7 +175,6 @@ func getAvailablePort() (int, error) {
 
 // Run starts up a local syncthing process to serve files from.
 func (s *Syncthing) Run(ctx context.Context, wg *sync.WaitGroup) error {
-	defer wg.Done()
 
 	if err := s.initConfig(); err != nil {
 		return err
@@ -214,7 +213,9 @@ func (s *Syncthing) Run(ctx context.Context, wg *sync.WaitGroup) error {
 
 	log.Infof("Syncthing running on http://%s and tcp://%s", s.GUIAddress, s.ListenAddress)
 
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		<-ctx.Done()
 		if err := s.Stop(); err != nil {
 			log.Error(err)


### PR DESCRIPTION

## Proposed changes
- follow the pattern where the creator of the goroutine owns increasing the sync group counter 
-  ensure that stop is called
- remove unnecesary ready channel on the port forwarding call
